### PR TITLE
Splitter wallet for escrow payments

### DIFF
--- a/contracts/Splitter.sol
+++ b/contracts/Splitter.sol
@@ -1,0 +1,65 @@
+pragma solidity ^0.4.18;
+
+
+import 'zeppelin-solidity/contracts/lifecycle/Pausable.sol';
+
+
+contract Splitter is Pausable {
+
+    mapping(address => uint256) public balances;
+    mapping(address => uint256) public split;
+    address[] public splitAddrs;
+
+    event LogWithdraw(address indexed beneficiary, uint256 amount);
+
+    function Splitter () public {
+        // set addresses and percentages
+        // percent value. 10000 = 100%, 75 = 0.75%, 750 = 7.5%, 7500 = 75%
+        split[0x627306090abab3a6e1400e9345bc60c78a8bef57] = 75;
+        splitAddrs.push(0x627306090abab3a6e1400e9345bc60c78a8bef57);
+
+        split[0xf17f52151ebef6c7334fad080c5704d77216b732] = 9925;
+        splitAddrs.push(0xf17f52151ebef6c7334fad080c5704d77216b732);
+
+        uint256 per;
+        for (uint256 i = 0; i < splitAddrs.length; i++) {
+            per += split[splitAddrs[i]];
+        }
+        // make sure that you split all 100%
+        require(per == 10000);
+    }
+
+    function () public payable whenNotPaused {
+        if (splitAddrs.length == 0) {
+            balances[owner] += msg.value;
+        } else {
+            for (uint256 i = 0; i < splitAddrs.length; i++) {
+                balances[splitAddrs[i]] = msg.value * split[splitAddrs[i]] / 10000;
+            }
+        }
+    }
+
+    function splitLength() public view returns(uint256) {
+        return splitAddrs.length;
+    }
+
+    function withdraw() public whenNotPaused returns(bool) {
+        uint256 value = balances[msg.sender];
+        balances[msg.sender] = 0;
+
+        LogWithdraw(msg.sender, value);
+        msg.sender.transfer(value);
+        return true;
+    }
+
+    function withdrawLeftover() public returns(bool) {
+        uint256 bal;
+        for (uint256 i = 0; i < splitAddrs.length; i++) {
+            bal += balances[splitAddrs[i]];
+        }
+        if (this.balance > bal) {
+            owner.transfer(this.balance - bal);
+        }
+        return true;
+    }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,7 @@
 var OdysseyPresaleToken = artifacts.require("OdysseyPresaleToken");
+var Splitter = artifacts.require("./Splitter.sol");
 
 module.exports = function(deployer) {
   deployer.deploy(OdysseyPresaleToken);
+  deployer.deploy(Splitter);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,11 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lite-server": "^2.3.0"
   },
   "dependencies": {
+    "bluebird": "^3.5.1",
     "zeppelin-solidity": "^1.4.0"
   }
 }

--- a/test/splitter.js
+++ b/test/splitter.js
@@ -1,0 +1,86 @@
+const Splitter = artifacts.require('./Splitter.sol');
+const Promise = require('bluebird');
+
+if (typeof web3.eth.getBlockPromise !== "function") {
+    Promise.promisifyAll(web3.eth, { suffix: "Promise" });
+}
+
+contract('Splitter', function(accounts) {
+    let spl, bob, alice, carol, transferValue, sum;
+
+    before("deploy new Splitter", async () => {
+        spl = await Splitter.new({from: accounts[3]});
+        bob = accounts[0];
+        alice = accounts[1];
+        carol = accounts[2];
+        transferValue = 12345;
+        sum = 0;
+    });
+
+
+    it('should split ether between peers', async () => {
+        let l = await spl.splitLength.call();
+
+        web3.eth.sendTransaction({to: spl.address, from: carol, value: transferValue});
+
+        for (var i = 0; i < l; i++) {
+            let addr = await spl.splitAddrs.call(i);
+            let percent = await spl.split.call(addr);
+            let val = transferValue * percent.div(10000);
+            let bal = await spl.balances.call(addr);
+            sum += bal.toNumber(); 
+            assert.equal(bal.toNumber(), Math.floor(val, 0), "Value incorrect for address " + addr);
+        }
+    });
+
+    it('should allow to withdraw funds', async () => {
+        var bobWBal = await spl.balances.call(bob);
+        var aliceWBal = await spl.balances.call(alice);
+
+        // withdraw bob
+        var bobBal = await web3.eth.getBalancePromise(bob);
+        var tx = await spl.withdraw({from: bob, gas: 200000});
+        var gasUsed = tx.receipt.gasUsed;
+        tx = web3.eth.getTransaction(tx.tx);
+        var gasPrice = tx.gasPrice.toNumber();
+
+        var txCost = gasPrice * gasUsed;
+        var bobNewBal = await web3.eth.getBalancePromise(bob);
+        assert(bobNewBal.plus(txCost).minus(bobWBal).toNumber(), bobBal.toNumber(), "Bob after withdraw balance incorrect.");
+        var bobWBal2 = await spl.balances.call(bob);
+        assert.equal(bobWBal2.toNumber(), 0 , "Splitter bob's balance incorrect.");
+
+        // withdraw alice
+        var aliceBal = await web3.eth.getBalancePromise(alice);
+        var tx = await spl.withdraw({from: alice, gas: 2000000});
+        var gasUsed = tx.receipt.gasUsed;
+        tx = web3.eth.getTransaction(tx.tx);
+        var gasPrice = tx.gasPrice.toNumber();
+
+        var txCost = gasPrice * gasUsed;
+        var aliceNewBal = await web3.eth.getBalancePromise(alice);
+        assert.equal(aliceNewBal.plus(txCost).minus(aliceWBal).toNumber(), aliceBal.toNumber(), "alice after withdraw balance incorrect.");
+        var aliceWBal2 = await spl.balances.call(bob);
+        assert.equal(aliceWBal2.toNumber(), 0 , "Splitter bob's balance incorrect.");
+    });
+
+    it('should allow to withdraw leftovers by owner', async () => {
+        let owner = accounts[3];
+        let left = transferValue - sum;
+
+        let splBal = await web3.eth.getBalancePromise(spl.address);
+
+        // withdraw bob
+        var ownerBal = await web3.eth.getBalancePromise(owner);
+        var tx = await spl.withdrawLeftover({from: owner});
+        var gasUsed = tx.receipt.gasUsed;
+        tx = web3.eth.getTransaction(tx.tx);
+        var gasPrice = tx.gasPrice.toNumber();
+
+        var txCost = gasPrice * gasUsed;
+        var ownerNewBal = await web3.eth.getBalancePromise(owner);
+        assert.equal(ownerNewBal.plus(txCost).minus(left).toNumber(), ownerBal.toNumber(), "Bob after withdraw balance incorrect.");
+
+    });
+    
+});


### PR DESCRIPTION
Simple contract that should be used as crowdsale wallet. It collects Ether and assigns balances to given addresses. That addresses can withdraw their balances at any time.

Before deployment, please set correct addresses and percentages in Splitter constructor.